### PR TITLE
Support newer base

### DIFF
--- a/Codec/Picture/RGBA8.hs
+++ b/Codec/Picture/RGBA8.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleContexts, MagicHash #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleContexts, MagicHash, CPP #-}
 module Codec.Picture.RGBA8 where
 
 import Codec.Picture
@@ -12,7 +12,11 @@ import System.IO.Unsafe
 import Data.Bits
 import GHC.Ptr
 import GHC.Base
+#if MIN_VERSION_base(4,15,0)
+import GHC.Integer
+#else
 import GHC.Num
+#endif
 
 class ToPixelRGBA8 a where
     toRGBA8 :: a -> PixelRGBA8


### PR DESCRIPTION
I have not been able to determine the origin of the problem, but wordToInteger is not resolvable after around base >=4.17.0.0.
At this point, GHC.Integer appears to be re-exported from GHC.Num. Curious.
    https://gitlab.haskell.org/ghc/ghc/-/blob/8e9ea0f91305d9e4bb9df3d89f6a9e223ecb4dd3/libraries/base/GHC/Num.hs#L26

Also, after
    https://gitlab.haskell.org/ghc/ghc/-/commit/d8d6ad8c6bba7010bb1d81ebf42543fce7caf4bd
GHC.Integer is no longer reexported from GHC.Num.

In any case, I would like to import directly from GHC.Integer to support the recent base.